### PR TITLE
added support for the tg:// format for deep links

### DIFF
--- a/tgbotapi.utils/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/utils/formatting/LinksFormatting.kt
+++ b/tgbotapi.utils/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/utils/formatting/LinksFormatting.kt
@@ -8,6 +8,7 @@ import io.ktor.http.encodeURLQueryComponent
 
 
 fun makeUsernameLink(username: String, threadId: MessageThreadId? = null) = "$internalLinkBeginning/$username${threadId ?.let { "/$it" } ?: ""}"
+fun makeTgUsernameLink(username: String) = "${internalTgAppLinksBeginning}resolve?domain=$username"
 fun makeUserLink(userId: UserId) = userId.userLink
 fun makeChatLink(identifier: Identifier, threadId: MessageThreadId? = null) = identifier.toString().replace(
     linkIdRedundantPartRegex,
@@ -16,6 +17,7 @@ fun makeChatLink(identifier: Identifier, threadId: MessageThreadId? = null) = id
     "$internalLinkBeginning/c/$bareId${threadId ?.let { "/$it" } ?: ""}"
 }
 fun makeUsernameDeepLinkPrefix(username: String) = "${makeUsernameLink(username)}?start="
+fun makeTgUsernameDeepLinkPrefix(username: String) = "${makeTgUsernameLink(username)}&start="
 fun makeUsernameStartattachPrefix(username: String) = "$internalLinkBeginning/$username?startattach"
 fun makeUsernameStartattachLink(username: String, data: String? = null) = "${makeUsernameStartattachPrefix(username)}${data?.let { "=$it" } ?: ""}"
 inline val Username.usernameLink
@@ -30,6 +32,8 @@ inline val Username.startattachPrefix
     get() = makeUsernameStartattachPrefix(usernameWithoutAt)
 inline fun makeLink(username: Username, threadId: MessageThreadId? = null) = username.link(threadId)
 inline fun makeTelegramDeepLink(username: String, startParameter: String) = "${makeUsernameDeepLinkPrefix(username)}$startParameter".encodeURLQueryComponent()
+inline fun makeTgDeepLink(username: String, startParameter: String) = "${makeTgUsernameDeepLinkPrefix(username)}$startParameter".encodeURLQueryComponent()
+inline fun makeTgDeepLink(username: Username, startParameter: String) = makeTgDeepLink(username.usernameWithoutAt, startParameter)
 inline fun makeTelegramStartattach(username: String, data: String? = null) = makeUsernameStartattachLink(username, data)
 inline fun makeDeepLink(username: Username, startParameter: String) = makeTelegramDeepLink(username.usernameWithoutAt, startParameter)
 inline fun makeTelegramDeepLink(username: Username, startParameter: String) = makeDeepLink(username, startParameter)


### PR DESCRIPTION
added support for the tg:// format for deep links

https://core.telegram.org/api/links#bot-links

<html>
<body>
<!--StartFragment--><p style="box-sizing: border-box; margin: 0px 0px 8.5px; font-size: 14px; line-height: 1.5; color: rgb(51, 51, 51); font-family: &quot;Lucida Grande&quot;, &quot;Lucida Sans Unicode&quot;, Arial, Helvetica, Verdana, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="box-sizing: border-box; font-family: Menlo, Monaco, Consolas, &quot;Courier New&quot;, monospace; font-size: 12.6px; padding: 3px 5px; color: rgb(198, 23, 23); background: rgb(254, 234, 228); border-radius: 0px; border: 0px;">tg:</code><span> </span>syntax:</p><pre style="box-sizing: border-box; overflow: auto; font-family: Menlo, Monaco, Consolas, &quot;Courier New&quot;, monospace; font-size: 13px; display: block; padding: 8px; margin: 0px 0px 8.5px; line-height: 1.42857; word-break: break-all; overflow-wrap: break-word; color: rgb(84, 97, 114); background: rgb(236, 243, 248); border: 0px; border-radius: 0px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="box-sizing: border-box; font-family: Menlo, Monaco, Consolas, &quot;Courier New&quot;, monospace; font-size: inherit; padding: 0px; color: inherit; background: transparent; border-radius: 0px; border: 0px; white-space: pre; overflow-wrap: normal;">tg://resolve?domain=&lt;bot_username&gt;&amp;start=&lt;parameter&gt;</code></pre><p style="box-sizing: border-box; margin: 0px 0px 8.5px; font-size: 14px; line-height: 1.5; color: rgb(51, 51, 51); font-family: &quot;Lucida Grande&quot;, &quot;Lucida Sans Unicode&quot;, Arial, Helvetica, Verdana, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Parameters:</p>

Name | Optional | Description
-- | -- | --
bot_username | Required | Bot username
parameter | Optional | Start parameter, up to 64 base64url characters: if provided and the bot_username is indeed a bot, the text input bar should be replaced with a Start button (even if the user has already started the bot) that should invoke messages.startBot with the appropriate parameter once clicked.

<!--EndFragment-->









