### PR TITLE
Bot API 7.7 (2)

### DIFF
--- a/tgbotapi.behaviour_builder/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/behaviour_builder/triggers_handling/EventTriggers.kt
+++ b/tgbotapi.behaviour_builder/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/behaviour_builder/triggers_handling/EventTriggers.kt
@@ -514,7 +514,22 @@ suspend fun <BC : BehaviourContext> BC.onSuccessfulPayment(
     scenarioReceiver: CustomBehaviourContextAndTypeReceiver<BC, Unit, ChatEventMessage<SuccessfulPaymentEvent>>
 ) = onEvent(initialFilter, subcontextUpdatesFilter, markerFactory, scenarioReceiver)
 
-// TODO: add documentation
+/**
+ * Please, remember that [RefundedPaymentEvent] will be retrieved only in case you will correctly handle
+ * [dev.inmo.tgbotapi.types.payments.PreCheckoutQuery] (via [onPreCheckoutQuery], for example)
+ *
+ * @param initialFilter This filter will be called to remove unnecessary data BEFORE [scenarioReceiver] call
+ * @param subcontextUpdatesFilter This filter will be applied to each update inside of [scenarioReceiver]. For example,
+ * this filter will be used if you will call [dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitContentMessage].
+ * Use [dev.inmo.tgbotapi.extensions.behaviour_builder.BehaviourContextAndTwoTypesReceiver] function to create your own.
+ * Use [dev.inmo.tgbotapi.extensions.behaviour_builder.utils.plus] or [dev.inmo.tgbotapi.extensions.behaviour_builder.utils.times]
+ * to combinate several filters
+ * @param [markerFactory] **Pass null to handle requests fully parallel**. Will be used to identify different "stream".
+ * [scenarioReceiver] will be called synchronously in one "stream". Output of [markerFactory] will be used as a key for
+ * "stream"
+ * @param scenarioReceiver Main callback which will be used to handle incoming data if [initialFilter] will pass that
+ * data
+ */
 suspend fun <BC : BehaviourContext> BC.onRefundedPayment(
     initialFilter: SimpleFilter<ChatEventMessage<RefundedPaymentEvent>>? = null,
     subcontextUpdatesFilter: CustomBehaviourContextAndTwoTypesReceiver<BC, Boolean, ChatEventMessage<RefundedPaymentEvent>, Update>? = MessageFilterByChat,

--- a/tgbotapi.behaviour_builder/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/behaviour_builder/triggers_handling/EventTriggers.kt
+++ b/tgbotapi.behaviour_builder/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/behaviour_builder/triggers_handling/EventTriggers.kt
@@ -515,9 +515,6 @@ suspend fun <BC : BehaviourContext> BC.onSuccessfulPayment(
 ) = onEvent(initialFilter, subcontextUpdatesFilter, markerFactory, scenarioReceiver)
 
 /**
- * Please, remember that [RefundedPaymentEvent] will be retrieved only in case you will correctly handle
- * [dev.inmo.tgbotapi.types.payments.PreCheckoutQuery] (via [onPreCheckoutQuery], for example)
- *
  * @param initialFilter This filter will be called to remove unnecessary data BEFORE [scenarioReceiver] call
  * @param subcontextUpdatesFilter This filter will be applied to each update inside of [scenarioReceiver]. For example,
  * this filter will be used if you will call [dev.inmo.tgbotapi.extensions.behaviour_builder.expectations.waitContentMessage].


### PR DESCRIPTION
- Bot API 7.7 implemented minor changes regarding refunded payments
- Bot API 7.7 implemented scanQrPopupClosed event
- optimization and conventions converted some objects with purpose to hold the data to data objects
- Bot API 7.7 fixed event handler for onScanQRPopupClosed event
- Bot API 7.7 now WebApp class supports vertical swipes to close and/or minimize the app
- Bot API 7.7 fixed RefundedPayment data class. providerPaymentChargeId is optional
- Bot API 7.7 added RefundedPaymentEvent
- Bot API 7.7 added waiters, triggers, and class casts for refunded payment event. added property handler in RawMessage.
- Bot API 7.7 added docs for event trigger
