### PR TITLE
Make MainButton.onClick(() -> Unit) and MainButton.offClick(() -> Unit) public

### DIFF
--- a/tgbotapi.webapps/src/jsMain/kotlin/dev/inmo/tgbotapi/webapps/MainButton.kt
+++ b/tgbotapi.webapps/src/jsMain/kotlin/dev/inmo/tgbotapi/webapps/MainButton.kt
@@ -36,6 +36,7 @@ data class MainButtonParams(
     val isVisible: Boolean? = null
 )
 
+@Deprecated(message="Use onClick without EventHandler")
 fun MainButton.onClick(eventHandler: EventHandler) = onClick {
     val that = js("this").unsafeCast<WebApp>()
     that.eventHandler()

--- a/tgbotapi.webapps/src/jsMain/kotlin/dev/inmo/tgbotapi/webapps/MainButton.kt
+++ b/tgbotapi.webapps/src/jsMain/kotlin/dev/inmo/tgbotapi/webapps/MainButton.kt
@@ -22,8 +22,8 @@ external class MainButton {
     fun showProgress(leaveActive: Boolean = definedExternally): MainButton
     fun hideProgress(): MainButton
 
-    internal fun onClick(eventHandler: () -> Unit): MainButton
-    internal fun offClick(eventHandler: () -> Unit): MainButton
+    fun onClick(eventHandler: () -> Unit): MainButton
+    fun offClick(eventHandler: () -> Unit): MainButton
 
     internal fun setParams(params: Json): MainButton
 }


### PR DESCRIPTION
Previous public visible function MainButton.onClick(EventHandler) marked as deprecated and can be removed in future

Reason: 
1) Usually if MainButton is called, there is WebApp in context.
2) If use MainButton.onClick(EventHandler) there is no way to unregister event listener, because lambda created once and passed same time to MainButton.onClick(() -> Unit), reference to it will be not returned.
3) Without MainButton.offClick(() -> Unit) there is no way to unregister event listener, which is useful in different cases when exist some screens with different MainButton configuration and listener inside.