### PR TITLE
Delay after executing action in sendActionDSL

### DIFF
--- a/tgbotapi.api/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/api/send/SendActionDSL.kt
+++ b/tgbotapi.api/src/commonMain/kotlin/dev/inmo/tgbotapi/extensions/api/send/SendActionDSL.kt
@@ -24,10 +24,10 @@ public suspend fun <T> TelegramBot.withAction(
     }
     val botActionJob = CoroutineScope(currentCoroutineContext()).launch {
         while (isActive) {
-            delay(refreshTime)
             safelyWithoutExceptions {
                 execute(actionRequest)
             }
+            delay(refreshTime)
         }
     }
     val result = safelyWithResult { block() }


### PR DESCRIPTION
Currently, actions are often being cancelled before ever getting executed, since there is a delay of 4 seconds before every execution

therefore, this code never sends typing

```kotlin
withTypingAction {
  delay(2.seconds)
  reply(it, "Waited to seconds
}
```