### PR TITLE
Use correct method name for createInvoiceLink.

### DIFF
--- a/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/requests/send/payments/CreateInvoiceLink.kt
+++ b/tgbotapi.core/src/commonMain/kotlin/dev/inmo/tgbotapi/requests/send/payments/CreateInvoiceLink.kt
@@ -54,7 +54,7 @@ data class CreateInvoiceLink(
     @SerialName(priceDependOnShipAddressField)
     override val priceDependOnShipAddress: Boolean = false
 ) : CommonSendInvoiceData, SimpleRequest<String> {
-    override fun method(): String = "sendInvoice"
+    override fun method(): String = "createInvoiceLink"
     override val resultDeserializer: DeserializationStrategy<String>
         get() = String.serializer()
     override val requestSerializer: SerializationStrategy<*>


### PR DESCRIPTION
Fixes use of `sendInvoice` by **createInvoiceLink**.